### PR TITLE
removed comma on line 25

### DIFF
--- a/arduino/package_sambar_index.json
+++ b/arduino/package_sambar_index.json
@@ -22,7 +22,7 @@
             {"name": "Arduino MKRZero"},
             {"name": "Arduino Zero"},
             {"name": "Eitech Robotics"},
-            {"name": "Wattuino RC"},
+            {"name": "Wattuino RC"}
           ]
         }
       ],


### PR DESCRIPTION
This fixed "package_sambar_index.json, parsing error occured:" in arduino IDE 1.8.5 when using boards manager